### PR TITLE
Slightly Safer cURL Extension Loader

### DIFF
--- a/inc/preheader.php
+++ b/inc/preheader.php
@@ -74,7 +74,7 @@
 	// Check for cURL
 	if(!extension_loaded("curl")){
 	    $prefix = (PHP_SHLIB_SUFFIX === "dll") ? "php_" : "";
-	    if(!@dl($prefix . "curl." . PHP_SHLIB_SUFFIX)){
+	    if(!function_exists("dl") || !@dl($prefix . "curl." . PHP_SHLIB_SUFFIX)){
 	        trigger_error("Unable to load the PHP cURL extension.", E_USER_ERROR);
 	        exit;
 	    }


### PR DESCRIPTION
According to PHP 5.3 docs, the dl() function "has been removed from some SAPI's in PHP 5.3."

I ran into this on my system so I added a function_exists check against dl().
