### PR TITLE
Change to images.php (extension)

### DIFF
--- a/extensions/images.php
+++ b/extensions/images.php
@@ -17,6 +17,25 @@
 		public function enhanceTweet($tweet){
 			$imgs  = array();
 			$links = findURLs($tweet['text']);
+
+			foreach($links as $link => $l){
+				$curl = curl_init($link);
+				curl_setopt_array($curl, array(
+								CURLOPT_USERAGENT => "Mozilla/5.0 (Compatible; libCURL)",
+								CURLOPT_TIMEOUT => 5,
+								CURLOPT_RETURNTRANSFER => 1,
+								CURLOPT_FOLLOWLOCATION => 1,
+								CURLOPT_MAXREDIRS => 3,
+								CURLOPT_NOBODY => 1,
+						));
+
+				$longurl = curl_exec($curl);
+				$url = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
+				$url = parse_url($url);
+
+				$links[$link] = $url;
+			}
+
 			foreach($links as $link => $l){
 				if(is_array($l) && array_key_exists("host", $l) && array_key_exists("path", $l)){
 					$domain = domain($l['host']);


### PR DESCRIPTION
I added in a rudimentary URL expander that ... expands short URLs. Technically it keeps hopping URLs until it reaches an endpoint; the code will tell you whatever you need to know.

This was mainly for t.co URLs that are just annoying, but it works for anything (long URLs are endpoints in themselves, so nothing happens). Makes fetching tweets a little slow (when we call loadtweets.php), but it's a pretty small delay.

_(If you want to test out my code, I have the same thing deployed [here](http://code.adityamukherjee.com/longurl.php?url=http://is.gd/5copUY), and [my tweetnest](http://adityamukherjee.com/tweets/) with the modification.)_

Cheers!
