### PR TITLE
Select most recent tweet id based on time rather than id

### DIFF
--- a/maintenance/loadtweets.php
+++ b/maintenance/loadtweets.php
@@ -71,7 +71,7 @@
 			$uid        = $pd['value'];
 			$screenname = $twitterApi->getScreenName($pd['value']);
 		}
-		$tiQ = $db->query("SELECT `tweetid` FROM `".DTP."tweets` WHERE `userid` = '" . $db->s($uid) . "' ORDER BY `id` DESC LIMIT 1");
+		$tiQ = $db->query("SELECT `tweetid` FROM `".DTP."tweets` WHERE `userid` = '" . $db->s($uid) . "' ORDER BY `time` DESC LIMIT 1");
 		if($db->numRows($tiQ) > 0){
 			$ti      = $db->fetch($tiQ);
 			$sinceID = $ti['tweetid'];


### PR DESCRIPTION
in the loadtweets.php script, select the most recent imported tweet id by sorting on the time column rather than the id column. This is more robust because it allows for inserting older tweets. When inserting an older tweet, it will get a higher id and loadtweets.php will get confused.

I ran into this situation when running my `loadoldtweets.php` script to import all my (3200+) tweets. I happen to have a list of all my tweet id's so I wrote that additional load-script to import 25 old tweets each time it is run. In case you are interested, you can find that script here: https://github.com/teranex/tweetnest/blob/master/maintenance/loadoldtweets.php
