### PR TITLE
Improve comments for access tokens in config file

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -11,8 +11,8 @@
 		'consumer_secret'    => '', // Your Twitter app consumer secret
 		'twitter_screenname' => '', // Twitter screen name of the one whose tweets are being recorded
 		'your_tw_screenname' => '', // Your Twitter screen name -- the one we log in as. Usually the same as above, but does not have to be.
-		'twitter_token'      => '', // Twitter OAuth secret token (usually filled in automatically)
-		'twitter_token_secr' => '', // Twitter OAuth token (usually filled in automatically)
+		'twitter_token'      => '', // Twitter OAuth access token (usually filled in automatically)
+		'twitter_token_secr' => '', // Twitter OAuth access token secret (usually filled in automatically)
 		'timezone'           => '', // Choose one of these: http://php.net/manual/en/timezones.php
 		'path'               => '', // Where's your twitter installation on your domain? No end slash, please.
 		// Database values


### PR DESCRIPTION
The comments for token/secret token look like they're the wrong way round. Also update them to use the language that Twitter uses to describe them on https://dev.twitter.com/.