### PR TITLE
Adding Q&D client-side support for RTL posts automatic redirection

### DIFF
--- a/extensions/bidi_tweets.js
+++ b/extensions/bidi_tweets.js
@@ -1,0 +1,110 @@
+/**
+ * hebrew4wp: incredibly simple Hebrew and Arabic support for bilingual WordPress installations
+ *  
+ * Copyright (c) 2008 Nadav Elyada <http://www.nadav.org/>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Hacked by Ira Abramov on 2013-02-19 to Bring the BiDi magic to Tweetnest
+ */
+
+/**
+ * Takes two function pointers f1 and f2, and returns a single function executing both f1 and f2.
+ * If either function is undefined, execution proceeds with the next defined function, if any.
+ * Inspired by Robert Hahn <http://blog.roberthahn.ca/>
+ */
+function biditweets_chain(f1, f2) {
+    return function() {
+        if(f1) {
+            f1();
+        }
+
+        if(f2) {
+            f2();
+        }
+    }
+}
+
+/**
+ * Takes the Unicode code of any character, and returns true if this character is an Hebrew character
+ * according to the Unicode standard; false otherwise.
+ */
+function biditweets_is_hebrew_char(c) {
+  //The range (0x05D0 thru 0x05EA) should be enough (?)
+  if((c >= 0x0590 && c <= 0x05FF) || (c >= 0xFB1D && c <= 0xFB40)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Takes the Unicode code of any character, and returns true if this character is an Arabic character
+ * according to the Unicode standard; false otherwise.
+ */
+function biditweets_is_arabic_char(c) {
+  if((c >= 0x0600 && c <= 0x06FF) || (c >= 0x0750 && c <= 0x077F) ||
+      (c >= 0xFB50 && c <= 0xFDFF) || (c >= 0xFE70 && c <= 0xFEFF)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Takes a string, and returns true if this string contains RTL text; false otherwise.
+ * This implementation treats any string containing one or more RTL characters as RTL text.
+ * This implementation considers all Hebrew and Arabic characters (as defined by the Unicode standard),
+ * and no other characters, to be RTL characters.
+ */
+function tweet_is_rtl_text(s) {
+  for(var i = 0; i < (s.length ); i++) {
+    var c = s.charCodeAt(i);
+
+    if(biditweets_is_hebrew_char(c) || biditweets_is_arabic_char(c)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The biditweets window.onload handler.
+ */
+function biditweets_onload() {
+  //Get all the elements in the document and walk over them
+  var elements = document.getElementsByClassName("tweettext");
+  for(var i = 0; i < elements.length; i++) {
+    var el = elements[i];
+    var entryHTML = el.innerHTML;
+
+    if(tweet_is_rtl_text(entryHTML)) {
+    //If any RTL characters are found, set the element's DIR attribute to "right-to-left".
+    el.dir = "rtl";
+    } else { el.dir = "ltr"; }
+  }
+}
+
+/**
+ * Chains the biditweets window.onload handler to any existing window.onload handlers.
+ */
+window.onload = biditweets_chain(window.onload, biditweets_onload);

--- a/inc/header.php
+++ b/inc/header.php
@@ -18,6 +18,7 @@
 	<link rel="stylesheet" href="<?php echo s($styleFile); ?>" type="text/css" />
 	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/<?php echo s($jQueryVersion); ?>/jquery.min.js"></script>
 	<script type="text/javascript" src="<?php echo $path; ?>/tweets.js"></script>
+	<script type="text/javascript" src="<?php echo $path; ?>/extensions/bidi_tweets.js"></script>
 </head>
 <body>
 	<div id="container">

--- a/inc/html.php
+++ b/inc/html.php
@@ -151,7 +151,7 @@
 		
 		$d  =   $t . "<div id=\"tweet-" . s($tweet['tweetid']) . "\" class=\"tweet" . (($tweet['type'] == 1) ? " reply" : "") . (($tweet['type'] == 2) ? " retweet" : "") . "\">\n" . 
 				($tweet['favorite'] ? $t . "\t<div class=\"fav\" title=\"A personal favorite\"><span>(A personal favorite)</span></div>\n" : "") .
-				$t . "\t<p class=\"text\">" . 
+				$t . "\t<p class=\"text tweettext\">" . 
 				($rt ? "<a class=\"rt\" href=\"http://twitter.com/" . $retweet['screenname'] . "\"><strong>" . $retweet['screenname'] . "</strong></a> " : "") . 
 				
 				nl2br(p(highlightQuery($htmlcontent, $tweet), 3)) . "</p>\n" . 


### PR DESCRIPTION
Tweets made in Hebrew, Arabic or Farsi need to be displayed right. This is a quick and dirty way or statistically deciding that at the client's side.
