### PR TITLE
Implemented proper support for service TweetNest via HTTPS 

### DIFF
--- a/authorize.php
+++ b/authorize.php
@@ -535,7 +535,7 @@ p.intro {
 			to use Tweet Nest, you have to <strong>register your Tweet Nest installation as an app with Twitter</strong>.</h2>
 		<p class="intro">If you haven&#8217;t already done so, here&#8217;s a link to Twitter&#8217;s Developer Site where you can
 			click the &#8220;Create new application&#8221; button to register (link opens in a new window):</p>
-		<p><a class="proceed" href="http://dev.twitter.com/apps" target="_blank">Go to Twitter&#8217;s Developer Site</a></p>
+		<p><a class="proceed" href="//dev.twitter.com/apps" target="_blank">Go to Twitter&#8217;s Developer Site</a></p>
 		<p class="intro">When you do that, you get two strings in return, labeled the <em>consumer key</em> and the <em>consumer secret</em>.
 			Paste them below:</p>
 
@@ -543,7 +543,7 @@ p.intro {
 		<div class="input">
 			<label for="consumer_key">Twitter consumer key</label>
 			<div class="field required"><input type="text" class="text code" name="consumer_key" id="consumer_key" value="<?php echo s($enteredConsumerKey); ?>" /></div>
-			<div class="what">The consumer key of an app created and registered on <a href="http://dev.twitter.com/apps" target="_blank">dev.twitter.com</a>.</div>
+			<div class="what">The consumer key of an app created and registered on <a href="//dev.twitter.com/apps" target="_blank">dev.twitter.com</a>.</div>
 		</div>
 		<div class="input">
 			<label for="consumer_secret">Twitter consumer secret</label>

--- a/callback.php
+++ b/callback.php
@@ -46,7 +46,7 @@
 	if(!defined('CONSUMER_KEY') || !CONSUMER_KEY || !defined('CONSUMER_SECRET') || !CONSUMER_SECRET){
 	    die('<strong>Consumer key and/or secret were not specified.</strong> Please check your configuration file, ' .
 	        'or if you were setting up Tweet Nest, please provide these values before authenticating. ' .
-	        'You can create them at <a href="http://dev.twitter.com/apps">dev.twitter.com</a>.');
+	        'You can create them at <a href="//dev.twitter.com/apps">dev.twitter.com</a>.');
 	}
 
 	// Create TwitterOAuth object with app key/secret and token key/secret from default phase

--- a/extensions/images.php
+++ b/extensions/images.php
@@ -95,15 +95,19 @@
 		}
 		
 		public function displayTweet($d, $tweet){
+			global $config;
+			$https_strict = $config['https_strict'];
 			@$tweetextra = unserialize($tweet['extra']);
 			if(is_array($tweetextra) && array_key_exists("imgs", $tweetextra)){
 				preg_match("/^([\t]+)</", $d, $m); $x = $m[1];
 				$ds    = explode("\n", $d, 2);
 				$imgd  = ""; $i = 1; $is = array();
 				foreach($tweetextra['imgs'] as $link => $img){
-					$imgd .= 
-						$x . "\t<a class=\"pic pic-" . s($i) . "\" href=\"" . s($link) . "\">" .
-						"<img src=\"" . s($img) . "\" alt=\"\" /></a>\n";
+					if(!$https_strict || substr(s($img), 0, 2) == "//" || substr(s($img), 0, 8) == "https://") {
+						$imgd .=
+							$x . "\t<a class=\"pic pic-" . s($i) . "\" href=\"" . s($link) . "\">" .
+							"<img src=\"" . s($img) . "\" alt=\"\" /></a>\n";
+					}
 					$is[$link] = $i++;
 				}
 				foreach($is as $link => $i){

--- a/extensions/images.php
+++ b/extensions/images.php
@@ -48,10 +48,10 @@
 					if($imgid){
 						if($domain == "twimg.com"){
 							$displaylink = $linkmap ? $linkmap[$link] : $link;
-							$imgs[$displaylink] = $http . "://pbs.twimg.com" . $l['path'] . ":thumb";
+							$imgs[$displaylink] = "//pbs.twimg.com" . $l['path'] . ":thumb";
 						}
 						if($domain == "twitpic.com"){
-							$imgs[$link] = $http . "://twitpic.com/show/thumb/" . $imgid;
+							$imgs[$link] = "//twitpic.com/show/thumb/" . $imgid;
 						}
 						if($domain == "yfrog.com" || $domain == "yfrog.us"){
 							$imgs[$link] = $http . "://yfrog.com/" . $imgid . ".th.jpg";
@@ -70,7 +70,7 @@
 							$imgs[$link] = $http . "://pict.mobi/show/thumb/" . $imgid;
 						}
 						if($domain == "imgur.com"){
-							$imgs[$link] = $http . "://i.imgur.com/" . $imgid . "s.jpg";
+							$imgs[$link] = "//i.imgur.com/" . $imgid . "s.jpg";
 						}
 						if($domain == "twitvid.com"){
 							$imgs[$link] = $http . "://images.twitvid.com/" . $imgid . ".jpg";

--- a/extensions/images.php
+++ b/extensions/images.php
@@ -53,27 +53,8 @@
 						if($domain == "twitpic.com"){
 							$imgs[$link] = "//twitpic.com/show/thumb/" . $imgid;
 						}
-						if($domain == "yfrog.com" || $domain == "yfrog.us"){
-							$imgs[$link] = $http . "://yfrog.com/" . $imgid . ".th.jpg";
-						}
-						if($domain == "tweetphoto.com" || $domain == "pic.gd" || $domain == "plixi.com"){
-							$imgs[$link] = $http . "://tweetphotoapi.com/api/TPAPI.svc/imagefromurl?size=thumbnail&url=" . $link;
-						}
-						if($domain == "twitgoo.com"){
-							$values = simplexml_load_string(getURL($http . "://twitgoo.com/api/message/info/" . $imgid));
-							$imgs[$link] = (string)$values->thumburl;
-						}
-						if($domain == "img.ly"){
-							$imgs[$link] = $http . "://img.ly/show/thumb/" . $imgid;
-						}
-						if($domain == "pict.mobi"){
-							$imgs[$link] = $http . "://pict.mobi/show/thumb/" . $imgid;
-						}
 						if($domain == "imgur.com"){
 							$imgs[$link] = "//i.imgur.com/" . $imgid . "s.jpg";
-						}
-						if($domain == "twitvid.com"){
-							$imgs[$link] = $http . "://images.twitvid.com/" . $imgid . ".jpg";
 						}
 						if($domain == "moby.to"){
 							$imgs[$link] = $http . "://moby.to/" . $imgid . ":square";

--- a/inc/class.twitterapi.php
+++ b/inc/class.twitterapi.php
@@ -142,7 +142,7 @@ require_once "twitteroauth/config.php";
 				if(property_exists($entity, 'expanded_url')){
 					$replacements[$entity->indices[0]] = array(
 						'end'     => $entity->indices[1],
-						'content' => $mediaUrl && $entity->media_url ? $entity->media_url : $entity->expanded_url
+						'content' => $mediaUrl && $entity->media_url_https ? $entity->media_url_https : $entity->expanded_url
 					);
 				}
 			}

--- a/inc/config.php
+++ b/inc/config.php
@@ -32,6 +32,7 @@
 		
 		'follow_me_button'   => true, // Display 'follow me' button?
 		'smartypants'        => true, // Use SmartyPants to perfect punctuation inside tweets?
+		'https_strict'       => false, // Disable inline images for HTTP-only image hosters?
 		
 		'css' => 'styles/streamlined/styles.css.php', // What CSS file should we use?
 		

--- a/inc/header.php
+++ b/inc/header.php
@@ -23,12 +23,12 @@
 	<div id="container">
 		<div id="top">
 			<div id="author">
-				<h2><a href="http://twitter.com/<?php echo s($config['twitter_screenname']); ?>"><strong><?php echo s($author['realname']); ?></strong> (@<?php echo s($config['twitter_screenname']); ?>)<img src="<?php echo s($author['profileimage']); ?>" width="48" height="48" alt="" /></a></h2>
+				<h2><a href="//twitter.com/<?php echo s($config['twitter_screenname']); ?>"><strong><?php echo s($author['realname']); ?></strong> (@<?php echo s($config['twitter_screenname']); ?>)<img src="<?php echo s($author['profileimage']); ?>" width="48" height="48" alt="" /></a></h2>
 				<p><?php echo s($author['location']); ?></p>
 			</div>
 			<div id="info">
 				<p>The below is an off-site archive of <strong><a href="<?php echo $path; ?>/">all tweets posted by @<?php echo s($config['twitter_screenname']); ?></a></strong> ever</p>
-<?php if($config['follow_me_button']){ ?>				<p class="follow"><a href="http://twitter.com/<?php echo s($config['twitter_screenname']); ?>">Follow me on Twitter</a></p><?php echo "\n"; } ?>
+<?php if($config['follow_me_button']){ ?>				<p class="follow"><a href="//twitter.com/<?php echo s($config['twitter_screenname']); ?>">Follow me on Twitter</a></p><?php echo "\n"; } ?>
 			</div>
 		</div>
 		<div id="content">

--- a/inc/html.php
+++ b/inc/html.php
@@ -456,7 +456,7 @@
 				$truncated = (!empty($entity->display_url) && mb_substr($entity->display_url, -1) == '…');
 				$replacements[$entity->indices[0]] = array(
 					'end'     => $entity->indices[1],
-					'content' => '<a class="media" href="' . s($entity->url) . '"' . $tb . ' data-image="' . s($entity->media_url) . '"' . 
+					'content' => '<a class="media" href="' . s($entity->url) . '"' . $tb . ' data-image="' . s($entity->media_url_https) . '"' . 
 								(!empty($entity->expanded_url) && $truncated ? ' title="' . s($entity->expanded_url) . '"' : '') . '>' . 
 								(!empty($entity->display_url) ? $entity->display_url : $entity->url) . '</a>'
 				);

--- a/inc/html.php
+++ b/inc/html.php
@@ -383,13 +383,13 @@
 	function _linkifyTweet_link($m){
 		$url = stripslashes($m[1]);
 		$end = stripslashes($m[4]);
-		return "<a class=\"link\" href=\"" . ($m[2][0] == "w" ? "http://" : "") . str_replace("\"", "&quot;", $url) . "\">" . (strlen($url) > 25 ? substr($url, 0, 24) . "..." : $url) . "</a>" . $end;
+		return "<a class=\"link\" href=\"" . ($m[2][0] == "w" ? "//" : "") . str_replace("\"", "&quot;", $url) . "\">" . (strlen($url) > 25 ? substr($url, 0, 24) . "..." : $url) . "</a>" . $end;
 	}
 	function _linkifyTweet_at($m){
-		return "<span class=\"at\">@</span><a class=\"user\" href=\"http://twitter.com/" . $m[1] . "\">" . $m[1] . "</a>";
+		return "<span class=\"at\">@</span><a class=\"user\" href=\"//twitter.com/" . $m[1] . "\">" . $m[1] . "</a>";
 	}
 	function _linkifyTweet_hashtag($m){
-		return "<a class=\"hashtag\" href=\"http://twitter.com/search?q=%23" . $m[1] . "\">#" . $m[1] . "</a>";
+		return "<a class=\"hashtag\" href=\"//twitter.com/search?q=%23" . $m[1] . "\">#" . $m[1] . "</a>";
 	}
 	function linkifyTweet($str, $linksOnly = false){
 		// Look behind (it kinda sucks, no | operator)
@@ -427,7 +427,7 @@
 		foreach($entities->user_mentions as $entity){
 			$replacements[$entity->indices[0]] = array(
 				'end'     => $entity->indices[1],
-				'content' => '<span class="at">@</span><a class="user"' . $tb . ' href="http://twitter.com/' . s($entity->screen_name) . '">' . s($entity->screen_name) . '</a>'
+				'content' => '<span class="at">@</span><a class="user"' . $tb . ' href="//twitter.com/' . s($entity->screen_name) . '">' . s($entity->screen_name) . '</a>'
 			);
 		}
 		
@@ -435,7 +435,7 @@
 		foreach($entities->hashtags as $entity){
 			$replacements[$entity->indices[0]] = array(
 				'end'     => $entity->indices[1],
-				'content' => '<a class="hashtag" rel="search"' . $tb . ' href="http://twitter.com/search?q=%23' . urlencode($entity->text) . '">#' . s($entity->text) . '</a>'
+				'content' => '<a class="hashtag" rel="search"' . $tb . ' href="//twitter.com/search?q=%23' . urlencode($entity->text) . '">#' . s($entity->text) . '</a>'
 			);
 		}
 		

--- a/inc/html.php
+++ b/inc/html.php
@@ -151,16 +151,16 @@
 		
 		$d  =   $t . "<div id=\"tweet-" . s($tweet['tweetid']) . "\" class=\"tweet" . (($tweet['type'] == 1) ? " reply" : "") . (($tweet['type'] == 2) ? " retweet" : "") . "\">\n" . 
 				($tweet['favorite'] ? $t . "\t<div class=\"fav\" title=\"A personal favorite\"><span>(A personal favorite)</span></div>\n" : "") .
-				$t . "\t<p class=\"text\">" . 
-				($rt ? "<a class=\"rt\" href=\"http://twitter.com/" . $retweet['screenname'] . "\"><strong>" . $retweet['screenname'] . "</strong></a> " : "") . 
-				
-				nl2br(p(highlightQuery($htmlcontent, $tweet), 3)) . "</p>\n" . 
-				
-				$t . "\t<p class=\"meta\">\n" . $t . "\t\t<a href=\"http://twitter.com/" . s($rt ? $retweet['screenname'] : $tweet['screenname']) . "/statuses/" . s($rt ? $retweet['tweetid'] : $tweet['tweetid']) . "\" class=\"permalink\">" . date("g:i A, M jS, Y", ($rt ? $retweet['time'] : $tweet['time'])) . "</a>\n" . 
+				$t . "\t<p class=\"text\">" .
+				($rt ? "<a class=\"rt\" href=\"//twitter.com/" . $retweet['screenname'] . "\"><strong>" . $retweet['screenname'] . "</strong></a> " : "") .
+
+				nl2br(p(highlightQuery($htmlcontent, $tweet), 3)) . "</p>\n" .
+
+				$t . "\t<p class=\"meta\">\n" . $t . "\t\t<a href=\"//twitter.com/" . s($rt ? $retweet['screenname'] : $tweet['screenname']) . "/statuses/" . s($rt ? $retweet['tweetid'] : $tweet['tweetid']) . "\" class=\"permalink\">" . date("g:i A, M jS, Y", ($rt ? $retweet['time'] : $tweet['time'])) . "</a>\n" .
 				$t . "\t\t<span class=\"via\">via " . ($rt ? $retweet['source'] : $tweet['source']) . "</span>\n" .
-				($rt ? $t . "\t\t<span class=\"rted\">(retweeted on " . date("g:i A, M jS, Y", $tweet['time']) . " <span class=\"via\">via " . $tweet['source'] . "</span>)</span>\n" : "") . 
-				((!$rt && $inReplyToTweetId) ? $t . "\t\t<a class=\"replyto\" href=\"http://twitter.com/" . s($tweetextra['in_reply_to_screen_name']) . "/statuses/" . s($inReplyToTweetId) . "\">in reply to " . s($tweetextra['in_reply_to_screen_name']) . "</a>\n" : "") . 
-				(($tweetplace && @$tweetplace->full_name) ? "\t\t<span class=\"place\">from <a href=\"http://maps.google.com/?q=" . urlencode($tweetplace->full_name) . "\">" . s($tweetplace->full_name) . "</a></span>" : "") .
+				($rt ? $t . "\t\t<span class=\"rted\">(retweeted on " . date("g:i A, M jS, Y", $tweet['time']) . " <span class=\"via\">via " . $tweet['source'] . "</span>)</span>\n" : "") .
+				((!$rt && $inReplyToTweetId) ? $t . "\t\t<a class=\"replyto\" href=\"//twitter.com/" . s($tweetextra['in_reply_to_screen_name']) . "/statuses/" . s($inReplyToTweetId) . "\">in reply to " . s($tweetextra['in_reply_to_screen_name']) . "</a>\n" : "") .
+				(($tweetplace && @$tweetplace->full_name) ? "\t\t<span class=\"place\">from <a href=\"//maps.google.com/?q=" . urlencode($tweetplace->full_name) . "\">" . s($tweetplace->full_name) . "</a></span>" : "") .
 				$t . "\t</p>\n" . $t . "</div>\n";
 		$dd = hook("displayTweet", array($d, $tweet));
 		if(!empty($dd)){ $d = $dd[0]; }

--- a/inc/preheader.php
+++ b/inc/preheader.php
@@ -121,17 +121,17 @@
 			return $a;
 		}
 	}
-	
+
 	function findURLs($str){
 		$urls = array();
 		preg_match_all("/\b(((https*:\/\/)|www\.).+?)(([!?,.\"\)]+)?(\s|$))/", $str, $m);
 		foreach($m[1] as $url){
-			$u = ($url[0] == "w") ? "http://" . $url : $url;
+			$u = ($url[0] == "w") ? "//" . $url : $url;
 			$urls[$u] = parse_url($u);
 		}
 		return $urls;
 	}
-	
+
 	function domain($host){
 		if(empty($host) || !is_string($host)){ return false; }
 		if(preg_match("/^[0-9\.]+$/", $host)){ return $host; } // IP

--- a/maintenance/loaduser.php
+++ b/maintenance/loaduser.php
@@ -37,9 +37,9 @@
 		$db->query("DELETE FROM `".DTP."tweetusers` WHERE `userid` = '0'"); // Getting rid of empty users created in error
 		$q = $db->query("SELECT * FROM `".DTP."tweetusers` WHERE `userid` = '" . $db->s($data->id_str) . "' LIMIT 1");
 		if($db->numRows($q) <= 0){
-			$iq = "INSERT INTO `".DTP."tweetusers` (`userid`, `screenname`, `realname`, `location`, `description`, `profileimage`, `url`, `extra`, `enabled`) VALUES ('" . $db->s($data->id_str) . "', '" . $db->s($data->screen_name) . "', '" . $db->s($data->name) . "', '" . $db->s($data->location) . "', '" . $db->s($data->description) . "', '" . $db->s($data->profile_image_url) . "', '" . $db->s($data->url) . "', '" . $db->s(serialize($extra)) . "', '1');";
+			$iq = "INSERT INTO `".DTP."tweetusers` (`userid`, `screenname`, `realname`, `location`, `description`, `profileimage`, `url`, `extra`, `enabled`) VALUES ('" . $db->s($data->id_str) . "', '" . $db->s($data->screen_name) . "', '" . $db->s($data->name) . "', '" . $db->s($data->location) . "', '" . $db->s($data->description) . "', '" . $db->s($data->profile_image_url_https) . "', '" . $db->s($data->url) . "', '" . $db->s(serialize($extra)) . "', '1');";
 		} else {
-			$iq = "UPDATE `".DTP."tweetusers` SET `screenname` = '" . $db->s($data->screen_name) . "', `realname` = '" . $db->s($data->name) . "', `location` = '" . $db->s($data->location) . "', `description` = '" . $db->s($data->description) . "', `profileimage` = '" . $db->s($data->profile_image_url) . "', `url` = '" . $db->s($data->url) . "', `extra` = '" . $db->s(serialize($extra)) . "' WHERE `userid` = '" . $db->s($data->id_str) . "' LIMIT 1";
+			$iq = "UPDATE `".DTP."tweetusers` SET `screenname` = '" . $db->s($data->screen_name) . "', `realname` = '" . $db->s($data->name) . "', `location` = '" . $db->s($data->location) . "', `description` = '" . $db->s($data->description) . "', `profileimage` = '" . $db->s($data->profile_image_url_https) . "', `url` = '" . $db->s($data->url) . "', `extra` = '" . $db->s(serialize($extra)) . "' WHERE `userid` = '" . $db->s($data->id_str) . "' LIMIT 1";
 		}
 		echo l("Updating...\n");
 		$q = $db->query($iq);

--- a/setup.php
+++ b/setup.php
@@ -138,7 +138,7 @@
                 exit;
             } else {
                 $e[] = 'Please fill in your <strong>Twitter app consumer key and secret</strong> before authenticating with Twitter. ' .
-                    'You can get these by creating an app at <a href="http://dev.twitter.com/apps">dev.twitter.com</a>.';
+                    'You can get these by creating an app at <a href="//dev.twitter.com/apps">dev.twitter.com</a>.';
             }
         }
 
@@ -656,7 +656,7 @@ INSTALL LOG: <?php var_dump($log); ?>
             <div class="input">
                 <label for="consumer_key">Twitter consumer key</label>
                 <div class="field required"><input type="text" class="text code" name="consumer_key" id="consumer_key" value="<?php echo s($enteredConsumerKey); ?>" /></div>
-                <div class="what">The consumer key of an app created and registered on <a href="http://dev.twitter.com/apps">dev.twitter.com</a>.</div>
+                <div class="what">The consumer key of an app created and registered on <a href="//dev.twitter.com/apps">dev.twitter.com</a>.</div>
             </div>
             <div class="input">
                 <label for="consumer_secret">Twitter consumer secret</label>

--- a/setup.php
+++ b/setup.php
@@ -252,6 +252,7 @@
 							$cf = configSetting($cf, "maintenance_http_password", $_POST['maintenance_http_password']);
 							$cf = configSetting($cf, "follow_me_button", !empty($_POST['follow_me_button']));
 							$cf = configSetting($cf, "smartypants", !empty($_POST['smartypants']));
+							$cf = configSetting($cf, "https_strict", !empty($_POST['https_strict']));
 							$f  = fopen("inc/config.php", "wt");
 							$fe = "Could not write configuration to <code>config.php</code>, please make sure that it is writable! Often, this is done through giving every system user the write privileges on that file through FTP.";
 							if($f){
@@ -740,10 +741,15 @@ INSTALL LOG: <?php var_dump($log); ?>
 				<div class="field"><input type="checkbox" class="checkbox" name="follow_me_button" id="follow_me_button" checked="checked" /></div>
 				<div class="what">Display a &#8220;Follow me on Twitter&#8221; button on your Tweet Nest page?</div>
 			</div>
-			<div class="input lastinput">
+			<div class="input">
 				<label for="smartypants">SmartyPants</label>
 				<div class="field"><input type="checkbox" class="checkbox" name="smartypants" id="smartypants" checked="checked" /></div>
 				<div class="what">Use <a href="http://daringfireball.net/projects/smartypants/" target="_blank">SmartyPants</a> to perfect punctuation inside tweets? Changes all "straight quotes" to &#8220;curly quotes&#8221; and more.</div>
+			</div>
+			<div class="input lastinput">
+				<label for="https_strict">HTTPS Strict</label>
+				<div class="field"><input type="checkbox" class="checkbox" name="https_strict" id="https_strict" checked="checked" /></div>
+				<div class="what">Enforce to only show inline images (&#8220;thumbnails&#8221;) when they come from HTTPS urls. If you are concerned about <a href="https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content" target="_blank">mixed content</a> (or just want to prevent the warnings from modern browsers), you should check this.</div>
 			</div>
 			
 			<h2>Style settings</h2>


### PR DESCRIPTION
Unfortunately TN was previously riddled with links forcing HTTP protocol. I changed everything I could find to protocol-relative URLs, and changed media-related URLs from API to their `_https` counterparts.

In addition to that I added a config option to enforce only displaying inline images if they are available via HTTPS (preventing loading mixed content). While checking the various image hosters for HTTPS availability I removed those, that have discontinued their service in the meantime.

Final thought: One might even argue for rewriting all protocol-relative URLs again to enforce HTTPS. For example Paul Irish already [advised for doing so in 2014](https://www.paulirish.com/2010/the-protocol-relative-url/).